### PR TITLE
Removed pretask to reboot worker host

### DIFF
--- a/ansible_worker.yaml
+++ b/ansible_worker.yaml
@@ -40,9 +40,6 @@
     apt:
       name: ['nvidia-driver-440', 'nvidia-cuda-dev']
 
-  - name: Reboot worker
-    reboot:
-
   roles:
   - role: indigo-dc.nfs
     nfs_mode: 'client'


### PR DESCRIPTION
When worker has a GPU deployment is not working ok and I think it is because of the reboot (master does not need it)